### PR TITLE
Added initialization-option

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -49,6 +49,15 @@ config-path
         eggs = myapp
         extra-paths = ${celery:config-path}
 
+initialization
+    The initialization option lets us specify custom Python code to be included in the scripts.
+    e.g. set an environment variable::
+
+        [celery]
+        recipe = collective.recipe.celery
+        initialization = import os
+                         os.environ['DJANGO_SETTINGS_MODULE'] = '${buildout:site_name}.${django:settings}'
+
 Celery options
 --------------
 

--- a/collective/recipe/celery/__init__.py
+++ b/collective/recipe/celery/__init__.py
@@ -58,6 +58,8 @@ class Recipe(object):
                                          + options['eggs'].split())
         if 'scripts' in options:
             celery_egg_options['scripts'] = options['scripts']
+        if 'initialization' in options:
+            celery_egg_options['initialization'] = options['initialization']
         celery_egg = zc.recipe.egg.Egg(
             self.buildout,
             self.name,


### PR DESCRIPTION
Since Celery 3.1 you no longer need a separate Django library to make it work and we find it useful to set an environment variable to specify Django settings in our buildout configs. However this recipe wasn't passing the 'initialization' option on to zc.recipe which would allow us to set arbitrary additional code to do this, so I tweaked it slightly.
### NOTE:

Not sure if this is the best implementation of the Django celery conf, but it does work for us. If needed, could put in a different README example.
